### PR TITLE
Use return value of fscanf

### DIFF
--- a/src/mmio.c
+++ b/src/mmio.c
@@ -77,6 +77,7 @@ int mm_read_unsymmetric_sparse(const char *fname, int *M_, int *N_, int *nz_,
     for (i=0; i<nz; i++)
     {
         int nr = fscanf(f, "%d %d %lg\n", &I[i], &J[i], &val[i]);
+	if (!nr) REprintf("fscanf failed at index %d", i);
         I[i]--;  /* adjust from 1-based to 0-based */
         J[i]--;
     }


### PR DESCRIPTION
Our tooling threw a warning that 'nr' is unused; may as well use the return value & error on failure.

Taken !nr from reading of https://www.tutorialspoint.com/c_standard_library/c_function_fscanf.htm