### PR TITLE
Avoid sys/timeb.h

### DIFF
--- a/src/commonlib.c
+++ b/src/commonlib.c
@@ -1,11 +1,7 @@
 
 #include <sys/types.h>
 
-#ifdef INTEGERTIME
-# include <time.h>
-#else
-# include <sys/timeb.h>
-#endif
+#include <time.h>
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/lp_utils.c
+++ b/src/lp_utils.c
@@ -5,7 +5,6 @@
 #include "lp_lib.h"
 #include "lp_utils.h"
 #include <time.h>
-#include <sys/timeb.h>
 
 #ifdef FORTIFY
 # include "lp_fortify.h"


### PR DESCRIPTION
Does not exist on OpenBSD, possibly elsewhere.